### PR TITLE
Add Piwik JavaScrip tracking code

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,5 +140,23 @@
         </div>
       </div>
     </footer>
+    <!-- Piwik -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
   </body>
 </html>


### PR DESCRIPTION
  * Use the same ID that www.o.o to track the search page
  * Track visitors across all subdomains
  * Prepend the site domain to the page title when tracking
  * In the "Outlinks" report, hide clicks to known alias URLs